### PR TITLE
TextモデルとMovieモデルの作成

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,2 @@
+class Movie < ApplicationRecord
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,0 +1,2 @@
+class Text < ApplicationRecord
+end

--- a/db/migrate/20210923024608_create_texts.rb
+++ b/db/migrate/20210923024608_create_texts.rb
@@ -1,0 +1,11 @@
+class CreateTexts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :texts do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210923025152_create_movies.rb
+++ b/db/migrate/20210923025152_create_movies.rb
@@ -1,0 +1,11 @@
+class CreateMovies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :movies do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_09_23_024608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "texts", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_23_024608) do
+ActiveRecord::Schema.define(version: 2021_09_23_025152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "movies", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false


### PR DESCRIPTION
close #4

## 実装内容
- `Text`モデルを作成してマイグレーションを実行
  - `genre`(`integer`)・`title`(`string`)・`content`(`text`)カラムを作成
  - 全てに`NOTNULL`制約を設定
  - `genre`のデフォルト値を0に設定

- Movieモデルを作成してマイグレーションを実行
  - `genre`(`integer`)・`title`(`string`)・`url`(`string`)カラムを作成
  - 全てに`NOTNULL`制約を設定
  - `genre`のデフォルト値を0に設定

## 確認内容
ターミナルで「`NOT NULL`制約が入っていること」と「`genre`カラムのデフォルト値が 0 になっていること」を確認。