### PR TITLE
ページ全体の設定を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,28 @@
  *= require_tree .
  *= require_self
  */
+
+/* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-sm {
+  max-width: 576px;
+}
+
+.mw-md {
+  max-width: 768px;
+}
+
+.mw-lg {
+  max-width: 992px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def max_width
+    if controller_name == "texts" && action_name == "show"
+      "mw-md"
+    # Devise 導入後にコメントアウトを解除
+    # elsif devise_controller?
+    #  "mw-sm"
+    else
+      "mw-xl"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,15 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <%= yield %>
+    <header>
+    </header>
+    <main>
+      <%# max_width メソッドは application_helper.rb に記載 %>
+      <div class="base-container <%= max_width %>">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION

close #3 

## 実装内容

- ページ全体に共通する内容が書かれているファイル app/views/layouts/application.html.erb を下記に変更
```
<header>
</header>
<main>
  <%# max_width メソッドは application_helper.rb に記載 %>
  <div class="base-container <%= max_width %>">
    <%= yield %>
  </div>
</main>
<footer>
</footer>
```
- 全ページに共通して必要なCSSを app/assets/stylesheets/application.css に設定
- 全体の横幅を設定する max_width メソッドを app/helpers/application_helper.rb に定義

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `rubocop -a` を実行