### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,24 +8,36 @@
 /* 全体 */
 
 .base-container {
-  margin: 0 auto;
-  padding: 1rem;
+    margin: 0 auto;
+    padding: 1rem;
 }
+
 
 /* max-width */
 
 .mw-sm {
-  max-width: 576px;
+    max-width: 576px;
 }
 
 .mw-md {
-  max-width: 768px;
+    max-width: 768px;
 }
 
 .mw-lg {
-  max-width: 992px;
+    max-width: 992px;
 }
 
 .mw-xl {
-  max-width: 1200px;
+    max-width: 1200px;
+}
+
+
+/* フラッシュ */
+
+.alert-notice {
+    @extend .alert-success;
+}
+
+.alert-alert {
+    @extend .alert-danger;
 }

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">x</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
       <%= render "layouts/header"%>
     </header>
     <main>
+      <%= render "layouts/flash" %>
       <%# max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
         <%= yield %>


### PR DESCRIPTION
close #12 

## 実装内容

- フラッシュの表示機能
  - 横幅いっぱいに(mainタグの開始タグのすぐ下に設置)
  - 部分テンプレート`app/views/layouts/_flash.html.erb`を作成して読み込み

- フラッシュの背景色を設定
  - noticeは`alert-success`, alertは`alert-danger`に設定

## 動作確認

- [x] ログイン時・ログアウト時にフラッシュが表示されることを確認