### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "2.7.3"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-i18n"
-gem 'enum_help'
+gem "enum_help"
 gem "jbuilder", "~> 2.7"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"

--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -1,0 +1,9 @@
+.text-card-container {
+  margin-top: 30px;
+}
+
+.card-style {
+  max-width: 376px;
+  height: 370px;
+  margin: 0 auto;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,7 @@
 class TextsController < ApplicationController
-  def index; end
+  def index
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+  end
 
   def show; end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -11,8 +11,8 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
 
-  RAILS_GENRE_LIST = %w[basic git ruby rails]
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -11,6 +11,8 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
+
+  RAILS_GENRE_LIST = %w[basic git ruby rails]
 end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,0 +1,16 @@
+<div class="col-12 col-md-6 col-lg-4 text-card-container">
+  <div class="card card-style">
+    <div class="card-header p-0">
+      <img class="img-fluid card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
+    </div>
+    <div class="card-body">
+      <p>
+        <button type="button" class="btn btn-secondary" style="width: 100%;">読破済み</button>
+      </p>
+      <div class="card-text">
+        <p><%= text.title %></p>
+        <p>【<%= text.genre_i18n %>】</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,1 +1,6 @@
-
+<h1 class="text-center">Ruby/Rails テキスト教材</h1>
+<div class="container">
+  <div class="row row-cols-3">
+    <%= render partial: "text", collection: @texts %>
+  </div>
+</div>


### PR DESCRIPTION
 close #13 

## 実装条件
 -  表示するジャンルは `Text::RAILS_GENRE_LIST` に制限
 -  `Bootstrap`の `Cards` や `Grid System` を用いて下図のようなスタイルにすること
 -  each を使わず「コレクションをレンダリング」を利用しましょう
 -  画像部分は デフォルト画像 を表示するのみとする
 -  カードの `height`, `max-width` を指定すること
 -  テキスト教材ページでしか利用しないスタイルは `app/assets/stylesheets/texts.scss` を作成して書き込むこと
 -  検索機能は実装しない
 -  広告は実装しない
 -  カード全体を「詳細ページ」へのリンクにする作業は別タスクとする
 -  「読破済みボタン」はボタンの配置のみとする。（機能は別タスクで実装）

## 参考資料（必要があれば）

[【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
[【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト
- [x] 画像のようにレスポンシブ対応ができているかどうかを確認
- [x] ブラウザの横幅次第でカードの横幅が長くなりすぎていないか確認
- [x] PHPのテキスト教材が表示されていないことを確認
- [x] 上記の実装条件を満たしているか確認
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行


## 備考
テキスト教材ページのHTMLでBootstrap以外にいくつかクラスを付与しています。
この辺りで問題ありそうであればSlackもしくはMTGで調整お願いします。