### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "2.7.3"
 
-gem "bootsnap", ">= 1.4.4", require: false
 gem "activeadmin"
+gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-bootstrap-views"
 gem "devise-i18n"

--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -24,5 +24,4 @@ ActiveAdmin.register AdminUser do
     end
     f.actions
   end
-
 end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -28,5 +28,5 @@ ActiveAdmin.register_page "Dashboard" do
     #     end
     #   end
     # end
-  end # content
+  end
 end

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,4 @@
+.movie-body {
+  height: 190px;
+  margin: 0 auto;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      width: 560,
+      height: 315,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+    )
+  end
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,6 @@
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -13,4 +13,6 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,13 @@
+<div class="col-12 col-md-6 col-lg-4">
+  <div class="card border-dark mb-3">
+    <div class="card-header p-0">
+      <div class="embed-responsive embed-responsive-16by9">
+        <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+      </div>
+      <div class="card-body text-dark movie-body">
+        <p><a class="btn btn-secondary btn-block">視聴済みにする</a></p>
+        <p class="card-text mt-3">Lv.<%= movie_counter + 1 %> : <%= movie.title %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,8 @@
-
+<div class="container mw-xl">
+  <div class="contents-title text-center">
+    <h1>Ruby/Rails 動画</h1>
+  </div>
+  <div class= "row">
+    <%= render partial: "movie", collection: @movies %>
+  </div>
+</div>

--- a/db/migrate/20211023013511_devise_create_admin_users.rb
+++ b/db/migrate/20211023013511_devise_create_admin_users.rb
@@ -32,7 +32,6 @@ class DeviseCreateAdminUsers < ActiveRecord::Migration[6.1]
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
 
-
       t.timestamps null: false
     end
 


### PR DESCRIPTION
close #15 

## 実装内容
- ```app/models/movie.rb``` に次を定義
 ``` 
RAILS_GENRE_LIST = %w[basic git ruby rails]
```
- Rails動画教材の一覧ページを作成
  - 表示するジャンルは ```Movie::RAILS_GENRE_LIST``` に制限
  - Bootstrapの ```Cards``` や ```Grid System``` を用いてスタイルする
  - ```each``` を使わず「コレクションをレンダリング」を利用
  - 各動画にレベル表示を入れる
  - カードの下側部分に ```height``` を指定して揃えること
  - 動画教材ページでしか利用しないスタイルは ```app/assets/stylesheets/movies.scss``` を作成して書き込む
  - 広告は実装しない
  - 「視聴済みボタン」はボタンの配置のみ

# 参考文献
- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
- [【公式】Embeds](https://getbootstrap.com/docs/4.5/utilities/embed/)
- [【やんばるエキスパート教材】YouTube動画の投稿](https://www.yanbaru-code.com/texts/349)

## 確認内容
- 画像のようにレスポンシブ対応ができているかどうかを確認
- カードの高さが一定になっているか確認
- PHPの動画教材が表示されていないことを確認

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
