### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,11 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.1"
 gem "rails-i18n", "~> 6.0"
+gem "redcarpet"
+gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "redcarpet"
-gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "redcarpet"
+gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,11 +213,13 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rouge (3.26.1)
     rubocop (1.18.4)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -305,6 +307,8 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
+  rouge
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,13 +6,17 @@
 @import 'bootstrap/scss/bootstrap';
 
 /* 全体 */
-body{
+body {
   padding-top: 69px;
 }
 
 .base-container {
   margin: 0 auto;
   padding: 1rem;
+}
+
+a:hover {
+  text-decoration: none;
 }
 
 /* max-width */

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -1,0 +1,46 @@
+@import 'bootstrap/scss/bootstrap';
+
+.markdown {
+  table {
+    @extend .table;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    border: initial;
+
+    thead {
+      background-color: #eeffff;
+    }
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    text-align: left;
+  }
+
+  pre {
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
+    background-color: #f6ffff;
+    padding: 0.5rem;
+    margin: 1rem 0;
+    border: 2px dashed #d6dddd;
+
+    code {
+      table.rouge-table {
+        margin: 0;
+
+        td.rouge-code {
+          padding: 0;
+          vertical-align: top;
+
+          pre {
+            padding: 5px 10px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,1 +1,1 @@
-<%= Rouge::Thenes::Github.render(scope: ".highlight") %>
+<%= Rouge::Themes::Github.render(scope: ".highlight") %>

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Thenes::Github.render(scope: ".highlight") %>

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,5 +3,7 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
   end
 
-  def show; end
+  def show
+    @text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,29 @@
+module MarkdownHelper
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+  end
+
+  private
+
+  def render_options
+    {
+      filter_html: false,
+      hard_wrap: true,
+      link_attributes: { target: "_blank", rel: "noopener" },
+    }
+  end
+
+  def extensions
+    {
+      autolink: true,
+      fenced_code_blocks: true,
+      no_intra_emphasis: true,
+      tables: true,
+      space_after_headers: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -10,7 +10,7 @@ module MarkdownHelper
     {
       filter_html: false,
       hard_wrap: true,
-      link_attributes: { target: "_blank", rel: "noopener" },
+      link_attributes: { target: "_blank", rel: "noopener" }
     }
   end
 
@@ -23,7 +23,7 @@ module MarkdownHelper
       space_after_headers: true,
       hard_wrap: true,
       xhtml: true,
-      lax_html_blocks: true,
+      lax_html_blocks: true
     }
   end
 end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,16 +1,18 @@
 <div class="col-12 col-md-6 col-lg-4 text-card-container">
-  <div class="card card-style">
-    <div class="card-header p-0">
-      <img class="img-fluid card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
-    </div>
-    <div class="card-body">
-      <p>
-        <button type="button" class="btn btn-secondary" style="width: 100%;">読破済み</button>
-      </p>
-      <div class="card-text">
-        <p><%= text.title %></p>
-        <p>【<%= text.genre_i18n %>】</p>
+  <%= link_to text_path(text) do %>
+    <div class="card card-style">
+      <div class="card-header p-0">
+        <img class="img-fluid card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
+      </div>
+      <div class="card-body">
+        <p>
+          <button type="button" class="btn btn-secondary" style="width: 100%;">読破済み</button>
+        </p>
+        <div class="card-text">
+          <p><%= text.title %></p>
+          <p>【<%= text.genre_i18n %>】</p>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,1 +1,4 @@
-
+<h1 class="text-center" style="margin: 20px;"><%= @text.title %></h1>
+<div class="markdown">
+  <%= markdown(@text.content) %>
+</div>


### PR DESCRIPTION
close #17

## 実装内容
-  一覧ページから詳細ページへの移動を実装
-  `redcarpet`, `rouge`をインストール
   -  `app/helpers/markdown_helper.rb` を作成してマークダウンの設定を追加
   -  `app/assets/stylesheets/rouge.scss.erb` を作成し，`Rouge` のシンタックスハイライト用のスタイルを追加
   -  `app/assets/stylesheets/markdown.scss` を作成し，マークダウン専用のスタイルを追加
-  テキスト教材の詳細ページを実装

## 確認内容
-  一覧ページのカードから対応する詳細ページに遷移できること
-  詳細ページで，下図のようにマークダウンを反映したスタイルとなっていること

## 参考資料
[【公式】Redcarpet](https://github.com/vmg/redcarpet)
[【公式】Rouge](https://github.com/rouge-ruby/rouge)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

