### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,9 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = if params[:genre] == 5
+                Movie.where(genre: Movie::PHP_GENRE_LIST)
+              else
+                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+              end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   def index
-    @movies = if params[:genre] == 5
+    @movies = if params[:genre] == "php"
                 Movie.where(genre: Movie::PHP_GENRE_LIST)
               else
                 Movie.where(genre: Movie::RAILS_GENRE_LIST)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_title
+    if params[:genre] == "php"
+      "PHP動画"
+    else
+      "Ruby/Rails動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,4 +15,5 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mw-xl">
   <div class="contents-title text-center">
-    <h1>Ruby/Rails 動画</h1>
+    <h1><%= movie_title %></h1>
   </div>
   <div class= "row">
     <%= render partial: "movie", collection: @movies %>


### PR DESCRIPTION
close #18 

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
  - PHP動画教材のリンクをクリックした際のクエリパラメータ`?genre=php` を利用
  - モデルにクラスメソッドを作成して対応

- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」に設定
  - `app/helpers/application_helper.rb` にメソッドを作成して対応

## チェックリスト

- [x] 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- [x] 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- [x] クエリパラメータ `?genre=php` を `php` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認
- [x] `rubocop -a` を実行