### PR TITLE
テキスト教材の読破済み機能の実装

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,2 @@
+class ReadProgressesController < ApplicationController
+end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,2 +1,11 @@
 class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.includes(:read_progresses).where(genre: Text::RAILS_GENRE_LIST)
   end
 
   def show

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,4 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,4 +1,9 @@
 class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
+
+  validates :user_id, uniqueness: {
+    scope: :text_id,
+    message: "は同じテキスト教材を読破済みにできません"
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,6 @@
 class Text < ApplicationRecord
+  has_many :read_progresses, dependent: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -17,4 +17,8 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  def read_by?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -19,6 +19,6 @@ class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
   def read_by?(user)
-    read_progresses.exists?(user_id: user.id)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :read_progresses, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("text-<%= @text.id %>").innerHTML = "<%= j render("texts/unread_progress", text: @text) %>"

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("text-<%= @text.id %>").innerHTML = "<%= j render("texts/read_progress", text: @text) %>"

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-block btn-secondary" %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, remote: true, class: "btn btn-block btn-secondary" %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-block btn-secondary" %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -7,9 +7,9 @@
       <div class="card-body">
         <p>
           <% if text.read_by?(current_user) %>
-            <%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-block btn-primary" %>
+            <%= render "unread_progress", text: text %>
           <% else %>
-            <%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-block btn-secondary" %>
+            <%= render "read_progress", text: text %>
           <% end %>
         </p>
         <div class="card-text">

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -6,7 +6,11 @@
       </div>
       <div class="card-body">
         <p>
-          <button type="button" class="btn btn-secondary" style="width: 100%;">読破済み</button>
+          <% if text.read_by?(current_user) %>
+            <%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-block btn-primary" %>
+          <% else %>
+            <%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-block btn-secondary" %>
+          <% end %>
         </p>
         <div class="card-text">
           <p><%= text.title %></p>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,7 +5,7 @@
         <img class="img-fluid card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
       </div>
       <div class="card-body">
-        <p>
+        <p id="text-<%= text.id %>">
           <% if text.read_by?(current_user) %>
             <%= render "unread_progress", text: text %>
           <% else %>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-block btn-primary" %>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-block btn-primary" %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, remote: true, class: "btn btn-block btn-primary" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       movie: 動画教材
       text: テキスト教材
+      read_progress: 読破済み
     attributes:
       movie:
         genre: ジャンル
@@ -12,6 +13,9 @@ ja:
         genre: ジャンル
         title: タイトル
         content: 内容
+      read_progress:
+        user: ユーザー
+        text: テキスト教材
   attributes:
     id: ID
     namespace: 名前空間

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index]
   root "texts#index"
 end

--- a/db/migrate/20211116193452_create_read_progresses.rb
+++ b/db/migrate/20211116193452_create_read_progresses.rb
@@ -1,0 +1,10 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211116193452_create_read_progresses.rb
+++ b/db/migrate/20211116193452_create_read_progresses.rb
@@ -6,5 +6,7 @@ class CreateReadProgresses < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+
+    add_index :read_progresses, [:user_id, :text_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_23_013514) do
+ActiveRecord::Schema.define(version: 2021_11_16_193452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_10_23_013514) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2021_10_23_013514) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #22

## 実装内容
- 読破済み機能に使用する`ReadProgress`モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる（`User`と`Text`の関連付けは未設定）

- テキスト教材一覧ページに読破済み機能を実装
  - 詳細ページには実装していない
  - 非同期で処理できるようにすること

- 読破済み機能におけるN+1問題の解消

## 確認内容
- テキスト教材一覧ページの読破済み機能が動作していることを確認
 
## 参考資料
- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）
](https://www.yanbaru-code.com/texts/297)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
